### PR TITLE
fix: object method needs "this" binding

### DIFF
--- a/src/task.js
+++ b/src/task.js
@@ -14,12 +14,7 @@ export default function createTask(
     notes: notes,
     checklist: false,
     check() {
-      if (checklist == false) {
-        checklist = true;
-      }
-      else {
-        checklist = false;
-      }
+      this.checklist = !this.checklist;
     }
   }
 }


### PR DESCRIPTION
When trying to edit variables within an object, you need to use this.value to edit the object's internals.