### PR TITLE
fix: use "this" in factory function methods

### DIFF
--- a/src/task.js
+++ b/src/task.js
@@ -32,19 +32,19 @@ export default function createTask(
       this.checklist = !checklist;
     },
     getTitle() {
-      return title;
+      return this.title;
     },
     getDes() {
-      return description;
+      return this.description;
     },
     getPrio() {
-      return prio;
+      return this.prio;
     },
     getNotes() {
-      return notes;
+      return this.notes;
     },
     getCheck() {
-      return checklist;
+      return this.checklist;
     }
   }
 }

--- a/src/todo.js
+++ b/src/todo.js
@@ -1,5 +1,4 @@
 export default function createToDo(name) {
-  name
   return {
     name: name,
     tasks: [],
@@ -7,7 +6,7 @@ export default function createToDo(name) {
       this.name = newName;
     },
     getName() {
-      return name;
+      return this.name;
     },
     removeTask(task) {
       for (let i = 0; i < this.tasks.length; i++) {


### PR DESCRIPTION
`this` is required for the methods to know they are referring to the object from which they are being called